### PR TITLE
Fix a memory bug where an empty array literal turns into nil

### DIFF
--- a/src/alloc.c
+++ b/src/alloc.c
@@ -496,8 +496,8 @@ void mrbc_cleanup_alloc(void)
 */
 void * mrbc_raw_alloc(unsigned int size)
 {
-  // can I just use platform's malloc?
   MRBC_ALLOC_MEMSIZE_T alloc_size = size + (-size & 3);	// align 4 byte
+  alloc_size = alloc_size > MRBC_MIN_MEMORY_BLOCK_SIZE ? alloc_size : MRBC_MIN_MEMORY_BLOCK_SIZE;
   return malloc(alloc_size);
 /*
   MEMORY_POOL *pool = memory_pool;
@@ -617,9 +617,8 @@ void * mrbc_raw_alloc(unsigned int size)
 
 void * mrbc_raw_alloc_no_free(unsigned int size)
 {
-  // let's just try the regular malloc and see what happens...
-  MRBC_ALLOC_MEMSIZE_T alloc_size = size + (-size & 3);	// align 4 byte
-  return mrbc_raw_alloc(alloc_size);
+  // let's just try the regular mrbc_raw_alloc and see what happens...
+  return mrbc_raw_alloc(size);
   /*
   MEMORY_POOL *pool = memory_pool;
   MRBC_ALLOC_MEMSIZE_T alloc_size = size + (-size & 3);	// align 4 byte
@@ -716,10 +715,10 @@ void * mrbc_raw_realloc(void *ptr, unsigned int size)
 {
   // platform realloc causes address error? Let's try a naive implementation for now...
   MRBC_ALLOC_MEMSIZE_T alloc_size = size + (-size & 3);	// align 4 byte
+  alloc_size = alloc_size > MRBC_MIN_MEMORY_BLOCK_SIZE ? alloc_size : MRBC_MIN_MEMORY_BLOCK_SIZE;
   void *newptr =  malloc(alloc_size);
   if( newptr == NULL ) return NULL;  // ENOMEM
   memcpy(newptr, ptr, size);
-  char buf[48];
   free(ptr);
   return newptr;
   //return ptr;

--- a/src/class.c
+++ b/src/class.c
@@ -470,7 +470,6 @@ int mrbc_run_mrblib(const void *bytecode)
   mrbc_vm_begin(vm);
   int ret = mrbc_vm_run(vm);
   mrbc_vm_end(vm);
-  // VDP_drawText("in run mrblib4", 10, 8);
 
   // instead of mrbc_vm_close()
   mrbc_raw_free( vm->top_irep );	// free only top-level mrbc_irep.
@@ -569,6 +568,5 @@ void mrbc_init_class(void)
   cls.cls = MRBC_CLASS(ZeroDivisionError);
   mrbc_set_const( MRBC_SYM(ZeroDivisionError), &cls );
 
-  // VDP_drawText("before run mrblib.", 10, 5);
   mrbc_run_mrblib(mrblib_bytecode);
 }

--- a/src/compat.c
+++ b/src/compat.c
@@ -9,7 +9,7 @@
 
 // hal_write implementation for now...
 int hal_write(int fd, const void *buf, int nbytes) {
-  static int8_t line = 20;
+  static int8_t line = 15;
   static char str[38];
   int len = 37;
   int remaining = nbytes+1;
@@ -20,7 +20,7 @@ int hal_write(int fd, const void *buf, int nbytes) {
   do {
     start = bufcpy;
     len = 37;
-    if(line > 26) line = 20;
+    if(line > 27) line = 15;
     if(remaining < 38) len = remaining;
 
     // fd values are just ignored

--- a/src/game.rb
+++ b/src/game.rb
@@ -1,5 +1,3 @@
-# MegaMrbc.draw_text("Hello, Megadrive from ruby/c")
-
 def draw_text(str, x, y)
   MegaMrbc.draw_text(str, x, y)
 end


### PR DESCRIPTION
There was a bug in memory allocation which caused `[]` to have no memory allocated, and turning into nil.
`[].push(1)` would cause unknown method 'push' for NilClass.

Now allocation of minimum amount happens in such a case, so empty array works properly as an empty array.